### PR TITLE
big, huge even

### DIFF
--- a/kubejs/assets/create/lang/en_us.json
+++ b/kubejs/assets/create/lang/en_us.json
@@ -1,6 +1,7 @@
 {
   "item.create.andesite_alloy": "Igneous Zinc Alloy",
   "item.create.electron_tube": "Primitive Electron Tube",
+  "item.create.super_glue": "Glue Tube",
   "block.create.andesite_casing": "Igneous Zinc Casing",
   "block.create.andesite_encased_cogwheel": "Igneous Zinc Encased Cogwheel",
   "block.create.andesite_encased_large_cogwheel": "Igneous Zinc Encased Large Cogwheel",

--- a/kubejs/assets/terrafirmacraft/en_us.json
+++ b/kubejs/assets/terrafirmacraft/en_us.json
@@ -1,0 +1,20 @@
+{
+    "item.terrafirmacraft.gem/opal": "Polished Opal",
+    "item.terrafirmacraft.ore/opal": "Tarnished Opal",
+    "item.terrafirmacraft.gem/diamond": "Polished Diamond",
+    "item.terrafirmacraft.ore/diamond": "Tarnished Diamond",
+    "item.terrafirmacraft.gem/sapphire": "Polished Sapphire",
+    "item.terrafirmacraft.ore/sapphire": "Tarnished Sapphire",
+    "item.terrafirmacraft.gem/amethyst": "Polished Amethyst",
+    "item.terrafirmacraft.ore/amethyst": "Tarnished Amethyst",
+    "item.terrafirmacraft.gem/pyrite": "Polished Pyrite",
+    "item.terrafirmacraft.ore/pyrite": "Tarnished Pyrite",
+    "item.terrafirmacraft.gem/topaz": "Polished Topaz",
+    "item.terrafirmacraft.ore/topaz": "Tarnished Topaz",
+    "item.terrafirmacraft.gem/ruby": "Polished Ruby",
+    "item.terrafirmacraft.ore/ruby": "Tarnished Ruby",
+    "item.terrafirmacraft.gem/emerald": "Polished Emerald",
+    "item.terrafirmacraft.ore/emerald": "Tarnished Emerald",
+    "item.terrafirmacraft.gem/lapis_lazuli": "Polished Lapis",
+    "item.terrafirmacraft.ore/lapis_lazuli": "Tarnished Lapis"
+}

--- a/kubejs/client_scripts/jei_removals.js
+++ b/kubejs/client_scripts/jei_removals.js
@@ -3,5 +3,19 @@ onEvent('jei.hide.items', event => {
 	// event.hide('minecraft:cobblestone')
 
 	event.hide('create:red_sand_paper')
+	event.hide('create:dough')
 
+
+
+	event.hide('minecraft:kelp')
+	event.hide('minecraft:dried_kelp')
+	event.hide('minecraft:dried_kelp_block')
+	event.hide('minecraft:torch')
+	event.hide('minecraft:soul_torch')
+	event.hide('minecraft:lantern')
+	event.hide('minecraft:soul_lantern')
+
+
+	event.hide('beyond_earth:coal_torch')
+	event.hide('beyond_earth:coal_lantern')
 })

--- a/kubejs/data/beyond_earth/recipes/coal_lantern.json
+++ b/kubejs/data/beyond_earth/recipes/coal_lantern.json
@@ -1,0 +1,7 @@
+{
+    "conditions": [
+      {
+        "type": "forge:false"
+      }
+    ]
+  }

--- a/kubejs/data/beyond_earth/recipes/coal_torch.json
+++ b/kubejs/data/beyond_earth/recipes/coal_torch.json
@@ -1,0 +1,7 @@
+{
+    "conditions": [
+      {
+        "type": "forge:false"
+      }
+    ]
+  }

--- a/kubejs/data/beyond_earth/recipes/wheel.json
+++ b/kubejs/data/beyond_earth/recipes/wheel.json
@@ -1,0 +1,22 @@
+{
+    "type": "minecraft:crafting_shaped",
+    "pattern": [
+      "BGB",
+      "GSG",
+      "BGB"
+    ],
+    "key": {
+      "B": {
+        "item": "minecraft:black_dye"
+      },
+      "G": {
+        "tag": "forge:glue"
+      },
+      "S": {
+        "tag": "forge:ingots/steel"
+      }
+    },
+    "result": {
+      "item": "beyond_earth:wheel"
+    }
+  }

--- a/kubejs/data/bloodmagic/recipes/array/bounce.json
+++ b/kubejs/data/bloodmagic/recipes/array/bounce.json
@@ -1,0 +1,7 @@
+{
+    "conditions": [
+      {
+        "type": "forge:false"
+      }
+    ]
+  }

--- a/kubejs/data/bloodmagic/recipes/array/day.json
+++ b/kubejs/data/bloodmagic/recipes/array/day.json
@@ -1,0 +1,7 @@
+{
+    "conditions": [
+      {
+        "type": "forge:false"
+      }
+    ]
+  }

--- a/kubejs/data/bloodmagic/recipes/array/movement.json
+++ b/kubejs/data/bloodmagic/recipes/array/movement.json
@@ -1,0 +1,7 @@
+{
+    "conditions": [
+      {
+        "type": "forge:false"
+      }
+    ]
+  }

--- a/kubejs/data/bloodmagic/recipes/array/night.json
+++ b/kubejs/data/bloodmagic/recipes/array/night.json
@@ -1,0 +1,7 @@
+{
+    "conditions": [
+      {
+        "type": "forge:false"
+      }
+    ]
+  }

--- a/kubejs/data/bloodmagic/recipes/array/spike.json
+++ b/kubejs/data/bloodmagic/recipes/array/spike.json
@@ -1,0 +1,7 @@
+{
+    "conditions": [
+      {
+        "type": "forge:false"
+      }
+    ]
+  }

--- a/kubejs/data/bloodmagic/recipes/array/updraft.json
+++ b/kubejs/data/bloodmagic/recipes/array/updraft.json
@@ -1,0 +1,7 @@
+{
+    "conditions": [
+      {
+        "type": "forge:false"
+      }
+    ]
+  }

--- a/kubejs/data/create/recipes/crafting/appliances/dough.json
+++ b/kubejs/data/create/recipes/crafting/appliances/dough.json
@@ -1,0 +1,7 @@
+{
+    "conditions": [
+      {
+        "type": "forge:false"
+      }
+    ]
+  }

--- a/kubejs/data/create/recipes/crafting/appliances/slime_ball.json
+++ b/kubejs/data/create/recipes/crafting/appliances/slime_ball.json
@@ -1,0 +1,7 @@
+{
+    "conditions": [
+      {
+        "type": "forge:false"
+      }
+    ]
+  }

--- a/kubejs/data/create/recipes/crafting/haunting/soul_torch.json
+++ b/kubejs/data/create/recipes/crafting/haunting/soul_torch.json
@@ -1,0 +1,7 @@
+{
+    "conditions": [
+      {
+        "type": "forge:false"
+      }
+    ]
+  }

--- a/kubejs/data/create/recipes/crafting/kinetics/adjustable_chain_gearshift.json
+++ b/kubejs/data/create/recipes/crafting/kinetics/adjustable_chain_gearshift.json
@@ -1,0 +1,17 @@
+{
+    "type": "minecraft:crafting_shaped",
+    "pattern": [
+      "DE"
+    ],
+    "key": {
+      "D": {
+        "item": "create:encased_chain_drive"
+      },
+      "E": {
+        "tag": "forge:electron_tube"
+      }
+    },
+    "result": {
+      "item": "create:adjustable_chain_gearshift"
+    }
+  }

--- a/kubejs/data/create/recipes/crafting/kinetics/clockwork_bearing.json
+++ b/kubejs/data/create/recipes/crafting/kinetics/clockwork_bearing.json
@@ -1,0 +1,22 @@
+{
+    "type": "minecraft:crafting_shaped",
+    "pattern": [
+      " S",
+      " C",
+      " E"
+    ],
+    "key": {
+      "S": {
+        "tag": "minecraft:wooden_slabs"
+      },
+      "C": {
+        "item": "create:brass_casing"
+      },
+      "E": {
+        "tag": "forge:electron_tube"
+      }
+    },
+    "result": {
+      "item": "create:clockwork_bearing"
+    }
+  }

--- a/kubejs/data/create/recipes/crafting/kinetics/controller_rail.json
+++ b/kubejs/data/create/recipes/crafting/kinetics/controller_rail.json
@@ -1,0 +1,22 @@
+{
+    "type": "minecraft:crafting_shaped",
+    "pattern": [
+      "G G",
+      "GSG",
+      "GEG"
+    ],
+    "key": {
+      "G": {
+        "tag": "forge:ingots/gold"
+      },
+      "S": {
+        "tag": "forge:rods/wooden"
+      },
+      "E": {
+        "tag": "forge:electron_tube"
+      }
+    },
+    "result": {
+      "item": "create:controller_rail"
+    }
+  }

--- a/kubejs/data/create/recipes/crafting/kinetics/deployer.json
+++ b/kubejs/data/create/recipes/crafting/kinetics/deployer.json
@@ -1,0 +1,22 @@
+{
+    "type": "minecraft:crafting_shaped",
+    "pattern": [
+      " E",
+      " C",
+      " H"
+    ],
+    "key": {
+      "H": {
+        "item": "create:brass_hand"
+      },
+      "C": {
+        "item": "create:andesite_casing"
+      },
+      "E": {
+        "tag": "forge:electron_tube"
+      }
+    },
+    "result": {
+      "item": "create:deployer"
+    }
+  }

--- a/kubejs/data/create/recipes/crafting/kinetics/display_board.json
+++ b/kubejs/data/create/recipes/crafting/kinetics/display_board.json
@@ -1,0 +1,18 @@
+{
+    "type": "minecraft:crafting_shaped",
+    "pattern": [
+      "   ",
+      "IEI"
+    ],
+    "key": {
+      "I": {
+        "item": "create:andesite_alloy"
+      },
+      "E": {
+        "tag": "forge:electron_tube"
+      }
+    },
+    "result": {
+      "item": "create:display_board"
+    }
+  }

--- a/kubejs/data/create/recipes/crafting/kinetics/hose_pulley.json
+++ b/kubejs/data/create/recipes/crafting/kinetics/hose_pulley.json
@@ -1,0 +1,25 @@
+{
+    "type": "minecraft:crafting_shaped",
+    "pattern": [
+      "KCK",
+      "K K",
+      "KPK"
+    ],
+    "key": {
+      "P": {
+        "tag": "forge:plates/copper"
+      },
+      "C": {
+        "item": "create:copper_casing"
+      },
+      "K": {
+        "type": "tfc:not_rotten",
+        "ingredient": {
+          "item": "tfc:food/dried_kelp"
+        }
+      }
+    },
+    "result": {
+      "item": "create:hose_pulley"
+    }
+  }

--- a/kubejs/data/create/recipes/crafting/kinetics/mechanical_crafter.json
+++ b/kubejs/data/create/recipes/crafting/kinetics/mechanical_crafter.json
@@ -1,0 +1,22 @@
+{
+    "type": "minecraft:crafting_shaped",
+    "pattern": [
+      " E",
+      " C",
+      " T"
+    ],
+    "key": {
+      "T": {
+        "item": "minecraft:crafting_table"
+      },
+      "C": {
+        "item": "create:brass_casing"
+      },
+      "E": {
+        "tag": "forge:electron_tube"
+      }
+    },
+    "result": {
+      "item": "create:mechanical_crafter"
+    }
+  }

--- a/kubejs/data/create/recipes/crafting/kinetics/nixie_tube.json
+++ b/kubejs/data/create/recipes/crafting/kinetics/nixie_tube.json
@@ -1,0 +1,14 @@
+{
+    "type": "minecraft:crafting_shaped",
+    "pattern": [
+      "EE"
+    ],
+    "key": {
+      "E": {
+        "tag": "forge:electron_tube"
+      }
+    },
+    "result": {
+      "item": "create:nixie_tube"
+    }
+  }

--- a/kubejs/data/create/recipes/crafting/kinetics/sequenced_gearshift.json
+++ b/kubejs/data/create/recipes/crafting/kinetics/sequenced_gearshift.json
@@ -1,0 +1,21 @@
+{
+    "type": "minecraft:crafting_shaped",
+    "pattern": [
+      "CW",
+      "E "
+    ],
+    "key": {
+      "W": {
+        "item": "create:cogwheel"
+      },
+      "C": {
+        "item": "create:brass_casing"
+      },
+      "E": {
+        "tag": "forge:electron_tube"
+      }
+    },
+    "result": {
+      "item": "create:sequenced_gearshift"
+    }
+  }

--- a/kubejs/data/create/recipes/crafting/kinetics/smart_chute.json
+++ b/kubejs/data/create/recipes/crafting/kinetics/smart_chute.json
@@ -1,0 +1,22 @@
+{
+    "type": "minecraft:crafting_shaped",
+    "pattern": [
+      " P",
+      " C",
+      " E"
+    ],
+    "key": {
+      "P": {
+        "tag": "forge:plates/brass"
+      },
+      "C": {
+        "item": "create:chute"
+      },
+      "E": {
+        "tag": "forge:electron_tube"
+      }
+    },
+    "result": {
+      "item": "create:smart_chute"
+    }
+  }

--- a/kubejs/data/create/recipes/crafting/kinetics/smart_fluid_pipe.json
+++ b/kubejs/data/create/recipes/crafting/kinetics/smart_fluid_pipe.json
@@ -1,0 +1,22 @@
+{
+    "type": "minecraft:crafting_shaped",
+    "pattern": [
+      " P",
+      " F",
+      " E"
+    ],
+    "key": {
+      "P": {
+        "tag": "forge:plates/brass"
+      },
+      "F": {
+        "item": "create:fluid_pipe"
+      },
+      "E": {
+        "tag": "forge:electron_tube"
+      }
+    },
+    "result": {
+      "item": "create:smart_fluid_pipe"
+    }
+  }

--- a/kubejs/data/create/recipes/crafting/kinetics/spout.json
+++ b/kubejs/data/create/recipes/crafting/kinetics/spout.json
@@ -1,0 +1,21 @@
+{
+    "type": "minecraft:crafting_shaped",
+    "pattern": [
+      "C",
+      "K"
+    ],
+    "key": {
+        "K": {
+            "type": "tfc:not_rotten",
+            "ingredient": {
+              "item": "tfc:food/dried_kelp"
+            }
+          },
+      "C": {
+        "item": "create:copper_casing"
+      }
+    },
+    "result": {
+      "item": "create:spout"
+    }
+  }

--- a/kubejs/data/create/recipes/crafting/kinetics/sticker.json
+++ b/kubejs/data/create/recipes/crafting/kinetics/sticker.json
@@ -1,0 +1,25 @@
+{
+    "type": "minecraft:crafting_shaped",
+    "pattern": [
+      "   ",
+      "AGA",
+      "SRS"
+    ],
+    "key": {
+      "G": {
+        "tag": "forge:glue"
+      },
+      "A": {
+        "item": "create:andesite_alloy"
+      },
+      "S":{
+        "tag": "forge:cobblestone"
+      },
+      "R":{
+        "item": "minecraft:redstone"
+      }
+    },
+    "result": {
+      "item": "create:sticker"
+    }
+  }

--- a/kubejs/data/create/recipes/crafting/kinetics/sticky_mechanical_piston.json
+++ b/kubejs/data/create/recipes/crafting/kinetics/sticky_mechanical_piston.json
@@ -1,0 +1,19 @@
+{
+    "type": "minecraft:crafting_shaped",
+    "pattern": [
+      " G ",
+      " P ",
+      "   "
+    ],
+    "key": {
+      "G": {
+        "tag": "forge:glue"
+      },
+      "P": {
+        "item": "create:mechanical_piston"
+      }
+    },
+    "result": {
+      "item": "create:sticky_mechanical_piston"
+    }
+  }

--- a/kubejs/data/create/recipes/crafting/kinetics/super_glue.json
+++ b/kubejs/data/create/recipes/crafting/kinetics/super_glue.json
@@ -12,11 +12,11 @@
       "G": {
         "tag": "forge:glue"
       },
-      "L": {
-        "tag": "forge:dyes/lime"
-      },
       "N": {
         "tag": "forge:nuggets/iron"
+      },
+      "L": {
+        "item": "minecraft:lime_dye"
       }
     },
     "result": {

--- a/kubejs/data/create/recipes/crafting/kinetics/track_signal.json
+++ b/kubejs/data/create/recipes/crafting/kinetics/track_signal.json
@@ -1,0 +1,17 @@
+{
+    "type": "minecraft:crafting_shaped",
+    "pattern": [
+      "CE"
+    ],
+    "key": {
+      "C": {
+        "item": "create:railway_casing"
+      },
+      "E": {
+        "tag": "forge:electron_tube"
+      }
+    },
+    "result": {
+      "item": "create:track_signal"
+    }
+  }

--- a/kubejs/data/create/recipes/crafting/logistics/andesite_funnel.json
+++ b/kubejs/data/create/recipes/crafting/logistics/andesite_funnel.json
@@ -9,7 +9,10 @@
       "item": "create:andesite_alloy"
     },
     "K": {
-      "item": "tfc:food/dried_kelp"
+      "type": "tfc:not_rotten",
+      "ingredient": {
+        "item": "tfc:food/dried_kelp"
+      }
     }
   },
   "result": {

--- a/kubejs/data/create/recipes/crafting/logistics/andesite_tunnel.json
+++ b/kubejs/data/create/recipes/crafting/logistics/andesite_tunnel.json
@@ -9,7 +9,10 @@
       "item": "create:andesite_alloy"
     },
     "K": {
-      "item": "tfc:food/dried_kelp"
+      "type": "tfc:not_rotten",
+      "ingredient": {
+        "item": "tfc:food/dried_kelp"
+      }
     }
   },
   "result": {

--- a/kubejs/data/create/recipes/crafting/logistics/brass_funnel.json
+++ b/kubejs/data/create/recipes/crafting/logistics/brass_funnel.json
@@ -10,7 +10,10 @@
       "tag": "forge:ingots/brass"
     },
     "K": {
-      "item": "tfc:food/dried_kelp"
+      "type": "tfc:not_rotten",
+      "ingredient": {
+        "item": "tfc:food/dried_kelp"
+      }
     },
     "E": {
       "tag": "forge:electron_tube"

--- a/kubejs/data/create/recipes/crafting/logistics/brass_tunnel.json
+++ b/kubejs/data/create/recipes/crafting/logistics/brass_tunnel.json
@@ -10,7 +10,10 @@
       "tag": "forge:ingots/brass"
     },
     "K": {
-      "item": "tfc:food/dried_kelp"
+      "type": "tfc:not_rotten",
+      "ingredient": {
+        "item": "tfc:food/dried_kelp"
+      }
     },
     "E": {
       "tag": "forge:electron_tube"

--- a/kubejs/data/create/recipes/crafting/logistics/content_observer.json
+++ b/kubejs/data/create/recipes/crafting/logistics/content_observer.json
@@ -1,0 +1,22 @@
+{
+    "type": "minecraft:crafting_shaped",
+    "pattern": [
+      " R",
+      " C",
+      " E"
+    ],
+    "key": {
+      "R": {
+        "item": "minecraft:comparator"
+      },
+      "C": {
+        "item": "create:andesite_casing"
+      },
+      "E": {
+        "tag": "forge:electron_tube"
+      }
+    },
+    "result": {
+      "item": "create:content_observer"
+    }
+  }

--- a/kubejs/data/create/recipes/crafting/materials/electron_tube.json
+++ b/kubejs/data/create/recipes/crafting/materials/electron_tube.json
@@ -14,7 +14,7 @@
       },
       "I":
       { 
-        "tag": "forge:plates/iron"
+        "tag": "forge:sheets/wrought_iron"
       },
       "C": {
         "tag": "forge:wires/copper"

--- a/kubejs/data/create/recipes/milling/saddle.json
+++ b/kubejs/data/create/recipes/milling/saddle.json
@@ -1,0 +1,16 @@
+{
+    "type": "create:milling",
+    "ingredients": [
+      {
+        "item": "minecraft:saddle"
+      }
+    ],
+    "results": [
+      {
+        "item": "minecraft:leather",
+        "count": 1,
+        "chance": 0.5
+      }
+    ],
+    "processingTime": 150
+  }

--- a/kubejs/data/create/recipes/milling/saltpeter.json
+++ b/kubejs/data/create/recipes/milling/saltpeter.json
@@ -7,11 +7,11 @@
     ],
     "results": [
       {
-        "item": "tfc:ore/saltpeter",
+        "item": "tfc:powder/saltpeter",
         "count": 4
       },
       {
-        "item": "tfc:ore/saltpeter",
+        "item": "tfc:powder/saltpeter",
         "count": 2,
         "chance": 0.45
       }

--- a/kubejs/data/create/recipes/sandpaper_polishing/amethyst.json
+++ b/kubejs/data/create/recipes/sandpaper_polishing/amethyst.json
@@ -1,0 +1,13 @@
+{
+  "type": "create:sandpaper_polishing",
+  "ingredients": [
+    {
+      "item": "tfc:ore/amethyst"
+    }
+  ],
+  "results": [
+    {
+      "item": "tfc:gem/amethyst"
+    }
+  ]
+}

--- a/kubejs/data/create/recipes/sandpaper_polishing/diamond.json
+++ b/kubejs/data/create/recipes/sandpaper_polishing/diamond.json
@@ -1,0 +1,13 @@
+{
+  "type": "create:sandpaper_polishing",
+  "ingredients": [
+    {
+      "item": "tfc:ore/diamond"
+    }
+  ],
+  "results": [
+    {
+      "item": "tfc:gem/diamond"
+    }
+  ]
+}

--- a/kubejs/data/create/recipes/sandpaper_polishing/emerald.json
+++ b/kubejs/data/create/recipes/sandpaper_polishing/emerald.json
@@ -1,0 +1,13 @@
+{
+  "type": "create:sandpaper_polishing",
+  "ingredients": [
+    {
+      "item": "tfc:ore/emerald"
+    }
+  ],
+  "results": [
+    {
+      "item": "tfc:gem/emerald"
+    }
+  ]
+}

--- a/kubejs/data/create/recipes/sandpaper_polishing/lapis.json
+++ b/kubejs/data/create/recipes/sandpaper_polishing/lapis.json
@@ -1,0 +1,13 @@
+{
+  "type": "create:sandpaper_polishing",
+  "ingredients": [
+    {
+      "item": "tfc:ore/lapis_lazuli"
+    }
+  ],
+  "results": [
+    {
+      "item": "tfc:gem/lapis_lazuli"
+    }
+  ]
+}

--- a/kubejs/data/create/recipes/sandpaper_polishing/opal.json
+++ b/kubejs/data/create/recipes/sandpaper_polishing/opal.json
@@ -1,0 +1,13 @@
+{
+  "type": "create:sandpaper_polishing",
+  "ingredients": [
+    {
+      "item": "tfc:ore/opal"
+    }
+  ],
+  "results": [
+    {
+      "item": "tfc:gem/opal"
+    }
+  ]
+}

--- a/kubejs/data/create/recipes/sandpaper_polishing/pyrite.json
+++ b/kubejs/data/create/recipes/sandpaper_polishing/pyrite.json
@@ -1,0 +1,13 @@
+{
+  "type": "create:sandpaper_polishing",
+  "ingredients": [
+    {
+      "item": "tfc:ore/pyrite"
+    }
+  ],
+  "results": [
+    {
+      "item": "tfc:gem/pyrite"
+    }
+  ]
+}

--- a/kubejs/data/create/recipes/sandpaper_polishing/ruby.json
+++ b/kubejs/data/create/recipes/sandpaper_polishing/ruby.json
@@ -1,0 +1,13 @@
+{
+  "type": "create:sandpaper_polishing",
+  "ingredients": [
+    {
+      "item": "tfc:ore/ruby"
+    }
+  ],
+  "results": [
+    {
+      "item": "tfc:gem/ruby"
+    }
+  ]
+}

--- a/kubejs/data/create/recipes/sandpaper_polishing/sapphire.json
+++ b/kubejs/data/create/recipes/sandpaper_polishing/sapphire.json
@@ -1,0 +1,13 @@
+{
+  "type": "create:sandpaper_polishing",
+  "ingredients": [
+    {
+      "item": "tfc:ore/sapphire"
+    }
+  ],
+  "results": [
+    {
+      "item": "tfc:gem/sapphire"
+    }
+  ]
+}

--- a/kubejs/data/create/recipes/sandpaper_polishing/topaz.json
+++ b/kubejs/data/create/recipes/sandpaper_polishing/topaz.json
@@ -1,0 +1,13 @@
+{
+  "type": "create:sandpaper_polishing",
+  "ingredients": [
+    {
+      "item": "tfc:ore/topaz"
+    }
+  ],
+  "results": [
+    {
+      "item": "tfc:gem/topaz"
+    }
+  ]
+}

--- a/kubejs/data/exmachinis/recipes/compacting/raw_copper_n.json
+++ b/kubejs/data/exmachinis/recipes/compacting/raw_copper_n.json
@@ -2,7 +2,7 @@
   "type": "exmachinis:compacting",
   "input": {
     "ingredient": {
-      "item": "tfc:ore/normal_native_copper"
+      "tag": "forge:copper_ore_n"
     },
     "count": 4
   },

--- a/kubejs/data/exmachinis/recipes/compacting/raw_copper_p.json
+++ b/kubejs/data/exmachinis/recipes/compacting/raw_copper_p.json
@@ -2,7 +2,7 @@
   "type": "exmachinis:compacting",
   "input": {
     "ingredient": {
-      "item": "tfc:ore/poor_native_copper"
+      "tag": "forge:copper_ore_p"
     },
     "count": 7
   },

--- a/kubejs/data/exmachinis/recipes/compacting/raw_copper_r.json
+++ b/kubejs/data/exmachinis/recipes/compacting/raw_copper_r.json
@@ -2,7 +2,7 @@
   "type": "exmachinis:compacting",
   "input": {
     "ingredient": {
-      "item": "tfc:ore/rich_native_copper"
+      "tag": "forge:copper_ore_r"
     },
     "count": 3
   },

--- a/kubejs/data/exmachinis/recipes/compacting/raw_iron_n.json
+++ b/kubejs/data/exmachinis/recipes/compacting/raw_iron_n.json
@@ -2,7 +2,7 @@
   "type": "exmachinis:compacting",
   "input": {
     "ingredient": {
-      "item": "tfc:ore/normal_hematite"
+      "tag": "forge:iron_ore_n"
     },
     "count": 4
   },

--- a/kubejs/data/exmachinis/recipes/compacting/raw_iron_p.json
+++ b/kubejs/data/exmachinis/recipes/compacting/raw_iron_p.json
@@ -2,7 +2,7 @@
   "type": "exmachinis:compacting",
   "input": {
     "ingredient": {
-      "item": "tfc:ore/poor_hematite"
+      "tag": "forge:iron_ore_p"
     },
     "count": 7
   },

--- a/kubejs/data/exmachinis/recipes/compacting/raw_iron_r.json
+++ b/kubejs/data/exmachinis/recipes/compacting/raw_iron_r.json
@@ -2,7 +2,7 @@
   "type": "exmachinis:compacting",
   "input": {
     "ingredient": {
-      "item": "tfc:ore/rich_hematite"
+      "tag": "forge:iron_ore_r"
     },
     "count": 3
   },

--- a/kubejs/data/immersiveengineering/recipes/crafting/torch.json
+++ b/kubejs/data/immersiveengineering/recipes/crafting/torch.json
@@ -1,0 +1,7 @@
+{
+    "conditions": [
+      {
+        "type": "forge:false"
+      }
+    ]
+  }

--- a/kubejs/data/minecraft/recipes/golden_apple.json
+++ b/kubejs/data/minecraft/recipes/golden_apple.json
@@ -1,0 +1,19 @@
+{
+    "type": "minecraft:crafting_shaped",
+    "pattern": [
+      "GGG",
+      "GAG",
+      "GGG"
+    ],
+    "key": {
+      "G": {
+        "tag": "forge:ingots/gold"
+      },
+      "A": {
+        "tag": "tfc:foods/apples"
+      }
+    },
+    "result": {
+      "item": "minecraft:golden_apple"
+    }
+  }

--- a/kubejs/data/minecraft/recipes/lantern.json
+++ b/kubejs/data/minecraft/recipes/lantern.json
@@ -1,0 +1,7 @@
+{
+    "conditions": [
+      {
+        "type": "forge:false"
+      }
+    ]
+  }

--- a/kubejs/data/minecraft/recipes/lead.json
+++ b/kubejs/data/minecraft/recipes/lead.json
@@ -1,0 +1,7 @@
+{
+    "conditions": [
+      {
+        "type": "forge:false"
+      }
+    ]
+  }

--- a/kubejs/data/minecraft/recipes/magma_cream.json
+++ b/kubejs/data/minecraft/recipes/magma_cream.json
@@ -1,0 +1,7 @@
+{
+    "conditions": [
+      {
+        "type": "forge:false"
+      }
+    ]
+  }

--- a/kubejs/data/minecraft/recipes/soul_lantern.json
+++ b/kubejs/data/minecraft/recipes/soul_lantern.json
@@ -1,0 +1,7 @@
+{
+    "conditions": [
+      {
+        "type": "forge:false"
+      }
+    ]
+  }

--- a/kubejs/data/mininggadgets/recipes/upgrade_silk.json
+++ b/kubejs/data/mininggadgets/recipes/upgrade_silk.json
@@ -1,0 +1,25 @@
+{
+    "type": "minecraft:crafting_shaped",
+    "pattern": [
+      "GAG",
+      "IBI",
+      "GGG"
+    ],
+    "key": {
+      "G": {
+        "tag": "forge:glue"
+      },
+      "I": {
+        "tag": "forge:ingots/gold"
+      },
+      "A":{
+        "item": "minecraft:golden_apple"
+      },
+      "B":{
+        "item": "mininggadgets:upgrade_empty"
+      }
+    },
+    "result": {
+      "item": "mininggadgets:upgrade_silk"
+    }
+  }

--- a/kubejs/data/thermal/recipes/aquachow_4.json
+++ b/kubejs/data/thermal/recipes/aquachow_4.json
@@ -1,0 +1,22 @@
+{
+    "type": "minecraft:crafting_shaped",
+    "pattern": [
+      "FF ",
+      "G  ",
+      "   "
+    ],
+    "key": {
+      "G": {
+        "tag": "forge:glue"
+      },
+      "F": {
+        "type": "tfc:not_rotten",
+        "ingredient": {
+          "tag": "tfc:foods/grains"
+        }
+      }
+    },
+    "result": {
+      "item": "thermal:aquachow"
+    }
+  }

--- a/kubejs/data/thermal/recipes/deep_aquachow_4.json
+++ b/kubejs/data/thermal/recipes/deep_aquachow_4.json
@@ -1,0 +1,31 @@
+{
+    "type": "minecraft:crafting_shaped",
+    "pattern": [
+      "FB ",
+      "GL ",
+      "   "
+    ],
+    "key": {
+      "G": {
+        "tag": "forge:glue"
+      },
+      "F": {
+        "type": "tfc:not_rotten",
+        "ingredient": {
+          "tag": "tfc:foods/grains"
+        }
+      },
+      "B": {
+        "type": "tfc:not_rotten",
+        "ingredient": {
+          "tag": "tfc:food/beet"
+        }
+      },
+      "L": {
+          "tag": "forge:nuggets/lead"
+      }
+    },
+    "result": {
+      "item": "thermal:deep_aquachow"
+    }
+  }

--- a/kubejs/server_scripts/item_tags.js
+++ b/kubejs/server_scripts/item_tags.js
@@ -19,4 +19,12 @@ onEvent('item.tags', event => {
     event.add('forge:brown_dye_material', ['tfc:plant/field_horsetail', 'tfc:plant/sargassum'])
     event.add('forge:red_dye_material', ['tfc:plant/tropical_milkweed', 'tfc:plant/snapdragon_red', 'tfc:plant/poppy', 'tfc:plant/guzmania', 'tfc:plant/tulip_red', 'tfc:plant/vriesea', 'tfc:plant/rose'])
 
+    event.add('forge:copper_ore_r', ['tfc:ore/rich_native_copper','tfc:ore/rich_tetrahedrite','tfc:ore/rich_malachite'])
+    event.add('forge:copper_ore_n', ['tfc:ore/normal_native_copper','tfc:ore/normal_tetrahedrite','tfc:ore/normal_malachite'])
+    event.add('forge:copper_ore_p', ['tfc:ore/poor_native_copper','tfc:ore/poor_tetrahedrite','tfc:ore/poor_malachite'])
+
+    event.add('forge:iron_ore_r', ['tfc:ore/rich_hematite','tfc:ore/rich_magnetite','tfc:ore/rich_limonite'])
+    event.add('forge:iron_ore_n', ['tfc:ore/normal_hematite','tfc:ore/normal_magnetite','tfc:ore/normal_limonite'])
+    event.add('forge:iron_ore_p', ['tfc:ore/poor_hematite','tfc:ore/poor_magnetite','tfc:ore/poor_limonite'])
+
 })

--- a/kubejs/server_scripts/script.js
+++ b/kubejs/server_scripts/script.js
@@ -88,7 +88,14 @@ event.remove({id: 'create:mixing/andesite_alloy'})
 
 
 modifyShaped(event, 'create:belt_connector', 1, ['   ', 'SSS', 'SSS'], {
-    S: 'tfc:food/dried_kelp'
+    S: {
+      "K": {
+        "type": "tfc:not_rotten",
+        "ingredient": {
+          "item": "tfc:food/dried_kelp"
+        }
+      }
+    }
   })
 
 

--- a/kubejs/server_scripts/script.js
+++ b/kubejs/server_scripts/script.js
@@ -88,14 +88,7 @@ event.remove({id: 'create:mixing/andesite_alloy'})
 
 
 modifyShaped(event, 'create:belt_connector', 1, ['   ', 'SSS', 'SSS'], {
-    S: {
-      "K": {
-        "type": "tfc:not_rotten",
-        "ingredient": {
-          "item": "tfc:food/dried_kelp"
-        }
-      }
-    }
+    S: 'tfc:food/dried_kelp'
   })
 
 


### PR DESCRIPTION
changes slime -> glue in recipes using it
removes vanilla/beyond earth torches/lanterns 
removes bedrock recipe
fixes leather/saltpeter dupes 
changes exmachinis compactor to use tags instead of items for iron/copper
makes all recipes using create:electron_tube use forge:electron_tube instead
adds polishing recipes for TFC gems
fixes all recipes that use kelp 
removes vanilla kelp/dried kelp/ kelp block
made golden apples craftable for mininggadgets
removed some vanilla recipes