### PR TITLE
fix recipes from ID, TFC Aerospace and rock slabs

### DIFF
--- a/kubejs/data/tfc_aerospace/recipes/aerospacefibercraft.json
+++ b/kubejs/data/tfc_aerospace/recipes/aerospacefibercraft.json
@@ -1,0 +1,27 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "item": "tfc_aerospace:polyester"
+    },
+    {
+      "item": "tfc_aerospace:cfrp"
+    },
+    {
+      "item": "tfc_aerospace:airgel"
+    },
+    {
+      "item": "tfc_aerospace:aluminiumfiber"
+    },
+    {
+      "item": "immersiveengineering:plate_duroplast"
+    },
+    {
+      "item": "ae2:silicon"
+    }
+  ],
+  "result": {
+    "item": "tfc_aerospace:aerospacefiber",
+    "count": 1
+  }
+}

--- a/kubejs/data/tfc_aerospace/recipes/cfrp_blue.json
+++ b/kubejs/data/tfc_aerospace/recipes/cfrp_blue.json
@@ -1,0 +1,29 @@
+{
+  "group": "cfrp",
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "012",
+    "34 "
+  ],
+  "key": {
+    "0": {
+      "item": "tfc:metal/sheet/blue_steel"
+    },
+    "1": {
+      "item": "tfc:metal/sheet/blue_steel"
+    },
+    "2": {
+      "item": "immersiveengineering:wirecutter"
+    },
+    "3": {
+      "item": "immersiveengineering:dust_hop_graphite"
+    },
+    "4": {
+      "item": "immersiveengineering:dust_hop_graphite"
+    }
+  },
+  "result": {
+    "item": "tfc_aerospace:cfrp",
+    "count": 12
+  }
+}

--- a/kubejs/data/tfc_aerospace/recipes/cfrp_red.json
+++ b/kubejs/data/tfc_aerospace/recipes/cfrp_red.json
@@ -1,0 +1,29 @@
+{
+  "group": "cfrp",
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "012",
+    "34 "
+  ],
+  "key": {
+    "0": {
+      "item": "tfc:metal/sheet/red_steel"
+    },
+    "1": {
+      "item": "tfc:metal/sheet/red_steel"
+    },
+    "2": {
+      "item": "immersiveengineering:wirecutter"
+    },
+    "3": {
+      "item": "immersiveengineering:dust_hop_graphite"
+    },
+    "4": {
+      "item": "immersiveengineering:dust_hop_graphite"
+    }
+  },
+  "result": {
+    "item": "tfc_aerospace:cfrp",
+    "count": 12
+  }
+}

--- a/kubejs/data/tfc_aerospace/recipes/polyestercraft.json
+++ b/kubejs/data/tfc_aerospace/recipes/polyestercraft.json
@@ -1,0 +1,18 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "item": "tfc_aerospace:alcohol"
+    },
+    {
+      "item": "immersivepetroleum:ethylene_bucket"
+    },
+    {
+      "item": "immersivepetroleum:crudeoil_bucket"
+    }
+  ],
+  "result": {
+    "item": "tfc_aerospace:polyester",
+    "count": 32
+  }
+}

--- a/kubejs/server_scripts/item_tags.js
+++ b/kubejs/server_scripts/item_tags.js
@@ -396,4 +396,9 @@ const setItemTags = itemTagsEvent => {
         "two",
         "four"
     ]
+
+    // Add slab for raw rock types
+    for (const tfcStoneType of tfcStoneTypes){
+        itemTagsEvent.add('tfc:raw_rock_slabs',[`tfc:rock/raw/${tfcStoneType}_slab`])
+    }
 }

--- a/kubejs/server_scripts/recipes.js
+++ b/kubejs/server_scripts/recipes.js
@@ -124,7 +124,16 @@ const removeRecipes = (recipesEvent) => {
 				console.log(`removing storagedrawers:${woodType}_trim`)
 				recipesEvent.remove({output: `storagedrawers:${woodType}_trim`})
 		}
-}
+
+		// Removing vanilla kelp
+		recipesEvent.remove({input: "minecraft:kelp"})
+		recipesEvent.remove({id: "integrateddynamics:drying_basin/convenience/minecraft_dried_kelp"})
+		recipesEvent.remove({id: "integrateddynamics:mechanical_drying_basin/convenience/minecraft_dried_kelp"})
+
+		// Removing dye from ID Squeezer
+		recipesEvent.remove({output: /minecraft:.*_dye/, mod:"integrateddynamics"})
+
+	}
 const setRecipes = (recipesEvent) => {
 		console.log("Loading recipes...");
 		// first remove unneeded ones....
@@ -156,7 +165,7 @@ const setRecipes = (recipesEvent) => {
 		recipesEvent.replaceInput({type: "minecraft:crafting_shaped", mod: "create"}, "minecraft:oak_planks", "#minecraft:planks")
 		recipesEvent.replaceInput({input: "minecraft:cobblestone", mod: "create"}, "minecraft:cobblestone", "#forge:cobblestone/normal")
 		recipesEvent.replaceInput({input: "minecraft:smooth_stone", mod: "create"}, "minecraft:smooth_stone", "#tfc:rock/smooth")
-		recipesEvent.replaceInput({input: "minecraft:stone_slab"}, "minecraft:stone_slab", "#minecraft:slabs")
+		recipesEvent.replaceInput({input: "minecraft:stone_slab"}, "minecraft:stone_slab", "#tfc:raw_rock_slabs")
 		recipesEvent.replaceInput({input: "minecraft:deepslate", mod: "supercircuitmaker"}, "minecraft:deepslate", "#tfc:rock/smooth")
 
 		recipesEvent.recipes.thermal.insolator([Item.of("tfc:jute").withChance(2), Item.of("tfc:seeds/jute").withChance(1.1)], "tfc:seeds/jute").water(900)
@@ -897,11 +906,11 @@ const setRecipes = (recipesEvent) => {
 
         // Integrated Dynamics... integration ?
         modifyShaped(recipesEvent, "integrateddynamics:part_machine_reader", 1, [
-            " D ",
+            " F ",
             "CIC",
             " S "
         ], {
-            "D": "integrateddynamics:part_display_panel",
+            "F": "thermal:machine_furnace",
             "C": "#forge:ingots/copper",
             "I": "integrateddynamics:variable_transformer_input",
             "S": "craftingstation:crafting_station"
@@ -935,10 +944,10 @@ const setRecipes = (recipesEvent) => {
             "CCC"
         ], {
             "C": "integrateddynamics:crystalized_menril_chunk",
-            "B": "#tfc:buckets"
+            "B": "tfc:wooden_bucket"
         })
 
-        modifyShaped(recipesEvent, "integratedtunnels:part_interface_fluid", 1, [
+        modifyShaped(recipesEvent, "integrateddynamics:part_entity_reader", 1, [
             " M ",
             "MVM",
             " M "
@@ -946,17 +955,22 @@ const setRecipes = (recipesEvent) => {
             "V": "integrateddynamics:variable_transformer_input",
             "M": "#tfc:foods/meats"
         })
-
-        modifyShaped(recipesEvent, "integratedtunnels:part_interface_fluid", 1, [
-            " M ",
-            "MVM",
-            " M "
-        ], {
-            "V": "integrateddynamics:variable_transformer_output",
-            "M": "#tfc:foods/meats"
-        })
-
+	
+		recipesEvent.remove({id: "integratedtunnels:crafting/part_importer_world_block"})
+		recipesEvent.remove({id: "integratedtunnels:crafting/part_exporter_world_block"})
 		
+		recipesEvent.shapeless("integratedtunnels:part_importer_world_block", [
+			"integratedtunnels:part_importer_item",
+			"integrateddynamics:logic_director",
+			Item.of('tfc:metal/pickaxe/blue_steel', '{Damage:0,"tfc:forging_bonus":4}').enchant('minecraft:silk_touch', 1)
+		]).id("kubejs:integratedtunnels/part_importer_world_block")
+		
+		recipesEvent.shapeless("integratedtunnels:part_exporter_world_block", [
+			"integratedtunnels:part_exporter_item",
+			"integrateddynamics:logic_director",
+			Item.of('tfc:metal/pickaxe/red_steel', '{Damage:0,"tfc:forging_bonus":4}').enchant('minecraft:silk_touch', 1)
+		]).id("kubejs:integratedtunnels/part_exporter_world_block")
+			
 		recipesEvent.shapeless("9x tfc:gem/lapis_lazuli", [
 			'#forge:storage_blocks/lapis'
 		]).id("kubejs:lapis_block_revert");


### PR DESCRIPTION
# Aerospace
- Replaced Mekanism recipes with Immersive Engineering/Petroleum counterparts

# TFC
- Added tfc:raw_rock_slabs to properly be able to craft grindstone

# Removing recipes
- Removed vanilla kelp and dye squeezing from ID

# Integrated Dynamics/Tunnels
- Replaced Display Panel to Thermal Furnace to recipe of Machine Reader (more inline with original recipe, a vanilla furnace), options are open like Crucible, TFC Bloom, TFC Blast Furnace, etc...
- Fixed and replaced Fluid Interface with wooden bucket (#tfc:bucket was too overwhelming)
- Fixed Entity Reader and duplicated entry
- Replaced uncraftable Diamond Pickaxe from Block Importer/Exporter to Blue/Red Steel Pickaxe, Perfectly Forged + Silk Touch, undamaged.