### PR TITLE
Suggest 2 Mod Additions, config changes included!

### DIFF
--- a/config/cobblegenrandomizer-common.toml
+++ b/config/cobblegenrandomizer-common.toml
@@ -1,0 +1,33 @@
+
+#General settings
+[general]
+	#Use config instead of datapack
+	use_config = true
+
+	#List settings
+	#Syntax: ["modid:block|weight"]
+	#Example: ["minecraft:stone|2","minecraft:dirt|1"]
+	#Forge tags are supported
+	[general.lists]
+		#Cobble gen
+		block_list_cobble = ["tfc:rock/hardened/rhyolite|1"]
+		#Stone gen
+		block_list_stone = ["tfc:rock/hardened/rhyolite|1"]
+		#Basalt gen
+		block_list_basalt = ["minecraft:basalt|1"]
+
+		#Custom settings
+		[general.lists.custom]
+			#Custom generators
+			#Syntax: [gen]
+			#Gen: [type, block, list]
+			#Type: cobblestone, stone
+			#Block: resource location of the block below the generated block
+			#List: see List settings
+			#Examples:
+			#custom_generators = [
+			#   ["cobblestone", "minecraft:diamond_block", ["minecraft:diamond_block"]],
+			#   ["cobblestone", "minecraft:dirt", ["forge:dirt"]],
+			#   ["cobblestone", "minecraft:white_wool", ["minecraft:wool"]]]
+			custom_generators = [["cobblestone", "tfc:rock/raw/granite", ["tfc:rock/raw/granite|1"]], ["cobblestone", "tfc:rock/raw/diorite", ["tfc:rock/raw/diorite|1"]], ["cobblestone", "tfc:rock/raw/gabbro", ["tfc:rock/raw/gabbro|1"]], ["cobblestone", "tfc:rock/raw/shale", ["tfc:rock/raw/shale|1"]], ["cobblestone", "tfc:rock/raw/claystone", ["tfc:rock/raw/claystone|1"]], ["cobblestone", "tfc:rock/raw/limestone", ["tfc:rock/raw/limestone|1"]], ["cobblestone", "tfc:rock/raw/conglomerate", ["tfc:rock/raw/conglomerate|1"]], ["cobblestone", "tfc:rock/raw/dolomite", ["tfc:rock/raw/dolomite|1"]], ["cobblestone", "tfc:rock/raw/chert", ["tfc:rock/raw/chert|1"]], ["cobblestone", "tfc:rock/raw/chalk", ["tfc:rock/raw/chalk|1"]], ["cobblestone", "tfc:rock/raw/rhyolite", ["tfc:rock/raw/rhyolite|1"]], ["cobblestone", "tfc:rock/raw/basalt", ["tfc:rock/raw/basalt|1"]], ["cobblestone", "tfc:rock/raw/andesite", ["tfc:rock/raw/andesite|1"]], ["cobblestone", "tfc:rock/raw/dacite", ["tfc:rock/raw/dacite|1"]], ["cobblestone", "tfc:rock/raw/quartzite", ["tfc:rock/raw/quartzite|1"]], ["cobblestone", "tfc:rock/raw/slate", ["tfc:rock/raw/slate|1"]], ["cobblestone", "tfc:rock/raw/schist", ["tfc:rock/raw/schist|1"]], ["cobblestone", "tfc:rock/raw/gneiss", ["tfc:rock/raw/gneiss|1"]], ["cobblestone", "tfc:rock/raw/marble", ["tfc:rock/raw/marble|1"]]]
+

--- a/kubejs/server_scripts/recipes.js
+++ b/kubejs/server_scripts/recipes.js
@@ -115,6 +115,11 @@ const removeRecipes = (recipesEvent) => {
 
 		recipesEvent.remove({input: "#forge:ores/apatite"})
 
+        recipesEvent.remove({id:"buildinggadgets:gadget_destruction"})
+        recipesEvent.remove({id:"buildinggadgets:construction_paste_powder"})
+        recipesEvent.remove({id:"buildinggadgets:construction_paste_container"})
+        recipesEvent.remove({id:"buildinggadgets:construction_paste_container_t2"})
+        recipesEvent.remove({id:"buildinggadgets:construction_paste_container_t3"})
 
 		const materials = ["oak", "birch", "dark_oak", "spruce", "acacia", "jungle"] // andesite, granite and diorite are obtainable
 		for (const woodType of vanillaWoodTypes) {
@@ -1148,7 +1153,7 @@ const setRecipes = (recipesEvent) => {
 			}
 		}
 
-		// Replacing vanilla emerald to tfc emerald for alien trading
+	    // Replacing vanilla emerald to tfc emerald for alien trading
 		recipesEvent.forEachRecipe({ id: /beyond_earth:alien_trading/ }, (r) => {
 			let tfcEmerald = "tfc:gem/emerald"
 			// console.log(r.getType())
@@ -1162,4 +1167,8 @@ const setRecipes = (recipesEvent) => {
 		})
 
 		recipesEvent.replaceInput({output:"minecraft:dried_kelp_block"}, `minecraft:dried_kelp`, `tfc:food/dried_kelp`)
+
+		for (const rockType of tfcStoneTypes) {
+			recipesEvent.recipes.createCutting(`tfc:brick/${rockType}`,`tfc:rock/loose/${rockType}`)
+		}
 }


### PR DESCRIPTION
This PR adds 2 things: A config for the mod [Cobble Gen Randomizer](https://www.curseforge.com/minecraft/mc-mods/cobblegenrandomizer) and recipe changes and such for [Building Gadgets](https://www.curseforge.com/minecraft/mc-mods/building-gadgets).

I shall now go into boring details as to why these two mods should be added.

**Mod A: Building Gadgets:** This pack lacks some building tools, and I feel like this mod effectively solves this problem. The tools are robust and easy to configure, and the void tool and construction paste have been disabled via kubejs recipes. The default recipes seemed well enough considering their value for building and the mining gadgets inclusion.

**Mod B: Cobble Gen Randomizer:** As above, building options. As currently configured via included config, does nothing to default TFC cobble generation _unless a block is placed below the generated stone_. Placing a _**Raw**_ stone from TFC under a cobble generator of some sort causes the generated stone to be replaced with another raw of that type. This allows for automation of the following with create:
TFC Cobblestone
TFC Bricks(Non-block)
TFC Sand
Mortar
Flux
[Possibly something I missed.]
I feel this is balanced and worth adding to the pack, as due to the stone below requirement, some sort of structure to generate and reliably mine the stone generated must be created. On top of that, it does not allow you to obtain any raw stone you have not already somehow collected via exploring.
This is nice for builders, who just need an absolute-metric f-ton of bricks for their castle.

As a bonus, these also allow you to make a factory for brick blocks using create, and I think that's just neat.


"Speedmerge me. Do it I dare you." - Len